### PR TITLE
Sonar Cleanup.

### DIFF
--- a/src/main/java/org/mybatis/cdi/CDIUtils.java
+++ b/src/main/java/org/mybatis/cdi/CDIUtils.java
@@ -31,7 +31,11 @@ import org.apache.ibatis.session.SqlSessionFactory;
  *
  * @author Frank D. Martinez [mnesarco]
  */
-public class CDIUtils {
+public final class CDIUtils {
+
+  private CDIUtils() {
+      // this class cannot be instantiated
+  }
 
   public static SqlSessionManagerRegistry getRegistry(BeanManager beanManager, CreationalContext creationalContext) {
     Iterator<Bean<?>> beans = beanManager.getBeans(SqlSessionManagerRegistry.class).iterator();
@@ -42,8 +46,7 @@ public class CDIUtils {
     Set<Bean<?>> beans;
     if (name != null) {
       beans = beanManager.getBeans(name);
-    }
-    else {
+    } else {
       beans = beanManager.getBeans(SqlSessionFactory.class, qualifiers.toArray(new Annotation[]{}));
     }
     Bean bean = beanManager.resolve(beans);
@@ -52,9 +55,13 @@ public class CDIUtils {
     }
     return (SqlSessionFactory) beanManager.getReference(bean, SqlSessionFactory.class, creationalContext);
   }
-  
-  public static class SerializableDefaultAnnotationLiteral extends AnnotationLiteral<Default> implements Serializable {}
 
-  public static class SerializableAnyAnnotationLiteral extends AnnotationLiteral<Any> implements Serializable {}
+  public static class SerializableDefaultAnnotationLiteral extends AnnotationLiteral<Default> implements Serializable {
+    private static final long serialVersionUID = 1L;
+  }
+
+  public static class SerializableAnyAnnotationLiteral extends AnnotationLiteral<Any> implements Serializable {
+    private static final long serialVersionUID = 1L;
+  }
 
 }

--- a/src/main/java/org/mybatis/cdi/Extension.java
+++ b/src/main/java/org/mybatis/cdi/Extension.java
@@ -16,6 +16,7 @@
 package org.mybatis.cdi;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -52,7 +53,7 @@ public class Extension implements javax.enterprise.inject.spi.Extension {
     final InjectionTarget<X> it = event.getInjectionTarget();
     for (final InjectionPoint ip : it.getInjectionPoints()) {
       if (ip.getAnnotated().isAnnotationPresent(Mapper.class) || SqlSession.class.equals(ip.getAnnotated().getBaseType())) {
-        mappers.add(new BeanKey((Class<?>) ip.getAnnotated().getBaseType(), ip.getAnnotated().getAnnotations()));
+        mappers.add(new BeanKey((Class<Type>) ip.getAnnotated().getBaseType(), ip.getAnnotated().getAnnotations()));
       }
     }
   }
@@ -72,11 +73,11 @@ public class Extension implements javax.enterprise.inject.spi.Extension {
 
     private final List<Annotation> qualifiers;
 
-    private final Class<?> type;
+    private final Class<Type> type;
 
     private final String sqlSessionManagerName;
 
-    public BeanKey(Class<?> type, Set<Annotation> annotations) {
+    public BeanKey(Class<Type> type, Set<Annotation> annotations) {
       this.type = type;
       this.qualifiers = sort(filterQualifiers(annotations));
 
@@ -138,7 +139,7 @@ public class Extension implements javax.enterprise.inject.spi.Extension {
         return false;
       }
       final BeanKey other = (BeanKey) obj;
-      return !((this.key == null) ? (other.key != null) : !this.key.equals(other.key));
+      return !(this.key == null ? other.key != null : !this.key.equals(other.key));
     }
 
     public Bean createBean(BeanManager bm) {

--- a/src/main/java/org/mybatis/cdi/JtaTransactionInterceptor.java
+++ b/src/main/java/org/mybatis/cdi/JtaTransactionInterceptor.java
@@ -17,7 +17,12 @@ package org.mybatis.cdi;
 
 import javax.inject.Inject;
 import javax.interceptor.Interceptor;
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
 import javax.transaction.Status;
+import javax.transaction.SystemException;
 import javax.transaction.UserTransaction;
 
 /**
@@ -30,21 +35,23 @@ import javax.transaction.UserTransaction;
 @Interceptor
 public class JtaTransactionInterceptor extends LocalTransactionInterceptor {
 
+  private static final long serialVersionUID = 1L;
+
   @Inject
   private transient UserTransaction userTransaction;
 
   @Override
-  protected boolean isTransactionActive() throws Exception {
+  protected boolean isTransactionActive() throws SystemException {
     return userTransaction.getStatus() != Status.STATUS_NO_TRANSACTION;
   }
-  
+
   @Override
-  protected void beginJta() throws Exception {
+  protected void beginJta() throws NotSupportedException, SystemException {
     userTransaction.begin();
   }
-  
+
   @Override
-  protected void endJta(boolean isExternaTransaction, boolean needsRollback) throws Exception {
+  protected void endJta(boolean isExternaTransaction, boolean needsRollback) throws SystemException, RollbackException, HeuristicMixedException, HeuristicRollbackException {
     if (isExternaTransaction) {
       if (needsRollback) {
         userTransaction.setRollbackOnly();

--- a/src/main/java/org/mybatis/cdi/MyBatisBean.java
+++ b/src/main/java/org/mybatis/cdi/MyBatisBean.java
@@ -39,7 +39,9 @@ import org.apache.ibatis.session.SqlSessionManager;
  */
 public class MyBatisBean implements Bean, Serializable {
 
-  protected final Class type;
+  private static final long serialVersionUID = 1L;
+
+  protected final Class<Type> type;
 
   protected final Set<Annotation> qualifiers;
 
@@ -47,7 +49,7 @@ public class MyBatisBean implements Bean, Serializable {
 
   protected final String sqlSessionFactoryName;
   
-  public MyBatisBean(Class type, Set<Annotation> qualifiers, String sqlSessionFactoryName, BeanManager beanManager) {  
+  public MyBatisBean(Class<Type> type, Set<Annotation> qualifiers, String sqlSessionFactoryName, BeanManager beanManager) {  
     this.type = type;
     this.sqlSessionFactoryName = sqlSessionFactoryName;
     this.beanManager = beanManager;    
@@ -55,23 +57,22 @@ public class MyBatisBean implements Bean, Serializable {
       this.qualifiers = new HashSet<Annotation>();
       this.qualifiers.add(new CDIUtils.SerializableDefaultAnnotationLiteral());
       this.qualifiers.add(new CDIUtils.SerializableAnyAnnotationLiteral());
-    }
-    else {
+    } else {
       this.qualifiers = qualifiers;
-    }    
+    }
   }
 
-  public Set getTypes() {
+  public Set<Type> getTypes() {
     Set<Type> types = new HashSet<Type>();
     types.add(type);
     return types;
   }
 
-  public Set getQualifiers() {
+  public Set<Annotation> getQualifiers() {
     return qualifiers;
   }
 
-  public Class getScope() {
+  public Class<Dependent> getScope() {
     return Dependent.class;
   }
 
@@ -79,11 +80,11 @@ public class MyBatisBean implements Bean, Serializable {
     return null;
   }
 
-  public Set getStereotypes() {
+  public Set<Object> getStereotypes() {
     return Collections.emptySet();
   }
 
-  public Class getBeanClass() {
+  public Class<Type> getBeanClass() {
     return type;
   }
 
@@ -95,15 +96,14 @@ public class MyBatisBean implements Bean, Serializable {
     return false;
   }
 
-  public Set getInjectionPoints() {
+  public Set<Object> getInjectionPoints() {
     return Collections.emptySet();
   }
 
   public Object create(CreationalContext creationalContext) {
     if (SqlSession.class.equals(type)) {
       return findSqlSessionManager(creationalContext);
-    }
-    else {
+    } else {
       return Proxy.newProxyInstance(
         SqlSessionFactory.class.getClassLoader(), 
         new Class[] {type}, 

--- a/src/main/java/org/mybatis/cdi/MybatisCdiConfigurationException.java
+++ b/src/main/java/org/mybatis/cdi/MybatisCdiConfigurationException.java
@@ -22,8 +22,10 @@ package org.mybatis.cdi;
  */
 public class MybatisCdiConfigurationException extends RuntimeException {
 
+  private static final long serialVersionUID = 1L;
+
   public MybatisCdiConfigurationException(String message) {
     super(message);
   }
-  
+
 }

--- a/src/main/java/org/mybatis/cdi/SerializableMapperProxy.java
+++ b/src/main/java/org/mybatis/cdi/SerializableMapperProxy.java
@@ -20,8 +20,11 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+
 import javax.enterprise.context.spi.CreationalContext;
+
 import org.apache.ibatis.session.SqlSessionFactory;
 
 /**
@@ -44,7 +47,7 @@ public class SerializableMapperProxy implements InvocationHandler, Serializable 
     this.mapper = getMapper();
   }
 
-  public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+  public Object invoke(Object proxy, Method method, Object[] args) throws IllegalAccessException, InvocationTargetException {
     return method.invoke(mapper, args);
   }
 

--- a/src/main/java/org/mybatis/cdi/SqlSessionManagerRegistry.java
+++ b/src/main/java/org/mybatis/cdi/SqlSessionManagerRegistry.java
@@ -43,8 +43,7 @@ public class SqlSessionManagerRegistry {
   public void init() {
     if (factories.isUnsatisfied()) {
       throw new MybatisCdiConfigurationException("There are no SqlSessionFactory producers properly configured.");
-    } 
-    else {
+    } else {
       Map<SqlSessionFactory, SqlSessionManager> m = new HashMap<SqlSessionFactory, SqlSessionManager>();
       for (SqlSessionFactory factory : factories) {
         SqlSessionManager manager = SqlSessionManager.newInstance(factory);
@@ -53,11 +52,11 @@ public class SqlSessionManagerRegistry {
       managers = Collections.unmodifiableMap(m);
     }
   }
-  
+
   public SqlSessionManager getManager(SqlSessionFactory factory) {
     return managers.get(factory);
   }
-  
+
   public Collection<SqlSessionManager> getManagers() {
     return managers.values();
   }

--- a/src/main/java/org/mybatis/cdi/Transactional.java
+++ b/src/main/java/org/mybatis/cdi/Transactional.java
@@ -76,5 +76,5 @@ public @interface Transactional {
    */
   @Nonbinding  
   Class<? extends Throwable>[] rollbackFor() default {};
-  
+
 }


### PR DESCRIPTION
Use more generics, throw proper errors, misc formatting.  All in an
effort to clear sonar warnings on library.
