### PR TITLE
Transaction Usage should be optional (Fixes #10)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.mybatis</groupId>
     <artifactId>mybatis-parent</artifactId>
-    <version>22-SNAPSHOT</version>
+    <version>24-SNAPSHOT</version>
   </parent>
 
   <artifactId>mybatis-cdi</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -102,13 +102,13 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.10</version>
+      <version>1.7.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>1.7.10</version>
+      <version>1.7.12</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/org/mybatis/cdi/JtaTransactionInterceptor.java
+++ b/src/main/java/org/mybatis/cdi/JtaTransactionInterceptor.java
@@ -15,6 +15,7 @@
  */
 package org.mybatis.cdi;
 
+import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import javax.interceptor.Interceptor;
 import javax.transaction.HeuristicMixedException;
@@ -38,29 +39,29 @@ public class JtaTransactionInterceptor extends LocalTransactionInterceptor {
   private static final long serialVersionUID = 1L;
 
   @Inject
-  private transient UserTransaction userTransaction;
+  private transient Instance<UserTransaction> userTransaction;
 
   @Override
   protected boolean isTransactionActive() throws SystemException {
-    return userTransaction.getStatus() != Status.STATUS_NO_TRANSACTION;
+    return userTransaction.get().getStatus() != Status.STATUS_NO_TRANSACTION;
   }
 
   @Override
   protected void beginJta() throws NotSupportedException, SystemException {
-    userTransaction.begin();
+    userTransaction.get().begin();
   }
 
   @Override
   protected void endJta(boolean isExternaTransaction, boolean needsRollback) throws SystemException, RollbackException, HeuristicMixedException, HeuristicRollbackException {
     if (isExternaTransaction) {
       if (needsRollback) {
-        userTransaction.setRollbackOnly();
+        userTransaction.get().setRollbackOnly();
       }
     } else {
       if (needsRollback) {
-        userTransaction.rollback();
+        userTransaction.get().rollback();
       } else {
-        userTransaction.commit();
+        userTransaction.get().commit();
       }
     }
   }


### PR DESCRIPTION
This fixes issue #10.  In servlet containers such as tomcat, transaction implementation is not provided by default.  Therefore JTA is made optional through use if CDI Instance.