### PR TITLE
Fixed #34 - Change bean-discovery-mode to "all"

### DIFF
--- a/src/main/resources/META-INF/beans.xml
+++ b/src/main/resources/META-INF/beans.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
-    version="1.1" bean-discovery-mode="annotated">
+    version="1.1" bean-discovery-mode="all">
 </beans>


### PR DESCRIPTION
Changing `bean-discovery-mode` seems to solve problems with:

 _LocalTransactionInterceptor (...) does not match an interceptor bean_ messages.