### PR TITLE
Improve CDI version compatibility.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,24 @@ jdk:
   - openjdk8
   - openjdk7
 
+script:
+  - ./mvnw test -B $MAVEN_PROFILE
+
 after_success:
   - chmod -R 777 ./travis/after_success.sh
   - "./travis/after_success.sh"
 
+matrix:
+  exclude:
+  - jdk: openjdk7
+    env: MAVEN_PROFILE="-Pcdi-2.0"
+
 env:
+  matrix:
+    - MAVEN_PROFILE="-Pcdi-2.0"
+    - MAVEN_PROFILE="-Pcdi-1.2"
+    - MAVEN_PROFILE="-Pcdi-1.1"
+    - MAVEN_PROFILE="-Pcdi-1.0"
   global:
     - secure: Yt0S6+G81okW0/575CBg9pP2CcNnilyar2KKDw+4bPnFxlMS0t4y1YyX08p/Zvj5/1q7n88NrPDFdnr/qwZ0gKjmKcYMm4WTCfy+UOPtYhyQSxX6aTYOhYDMpbAQ84jB3Gh70mG52ULXxF56Hc5bNAXT0lSNfIAOndrF/LIBJAU=
     - secure: QAeXjP+BabMYAHSivnbYaxrcr9pj6+FBEO/fpTlB4M0W5nALBoj8nVTOVYGv6zQHV1cxDv4DOLUxg/2sDcrWPyHV+8xbXbHvXK80T4wgeTc/SFEGOINMm/oXGdTGtY6lJ6i5VEDGwJDMRUt+M/W22HD0lqUZNDJ8xL5PAwKVr6g=

--- a/README.md
+++ b/README.md
@@ -13,10 +13,16 @@ MyBatis-CDI extension takes care of the lifecycle of MyBatis mappers and SqlSess
 CDI beans ready to be used, there is no need to create or destroy them. It also provides local and JTA transaction support based on the
 @Transactional annotation.
 
-Important
----------
+Compatibility
+-------------
 
-CDI 1.0 is not supported. This extension requieres minimum CDI 1.1, CDI 1.2 is prefered.
+| CDI API VERSION     | Oracle JDK 8 | OpenJDK 8 | OpenJDK 7 |
+| ------------------- | ------------ | --------- | --------- |
+| cdi-1.0             | Y            | Y         | Y         |
+| cdi-1.1             | Y            | Y         | Y         |
+| cdi-1.2 (preferred) | Y            | Y         | Y         |
+| cdi-2.0             | Y            | Y         | N         |
+
 
 Essentials
 ----------

--- a/pom.xml
+++ b/pom.xml
@@ -72,12 +72,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se</artifactId>
-      <version>2.4.4.Final</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jboss.spec.javax.transaction</groupId>
       <artifactId>jboss-transaction-api_1.2_spec</artifactId>
       <version>1.0.0.Final</version>
@@ -160,5 +154,79 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>cdi-2.0</id>
+      <dependencies>
+        <dependency>
+          <groupId>javax.enterprise</groupId>
+          <artifactId>cdi-api</artifactId>
+          <version>2.0</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss.weld.se</groupId>
+          <artifactId>weld-se-core</artifactId>
+          <version>3.0.1.Final</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>cdi-1.2</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>javax.enterprise</groupId>
+          <artifactId>cdi-api</artifactId>
+          <version>1.2</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss.weld.se</groupId>
+          <artifactId>weld-se</artifactId>
+          <version>2.4.5.Final</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>cdi-1.1</id>
+      <dependencies>
+        <dependency>
+          <groupId>javax.enterprise</groupId>
+          <artifactId>cdi-api</artifactId>
+          <version>1.1</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss.weld.se</groupId>
+          <artifactId>weld-se</artifactId>
+          <version>2.1.2.Final</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>cdi-1.0</id>
+      <dependencies>
+        <dependency>
+          <groupId>javax.enterprise</groupId>
+          <artifactId>cdi-api</artifactId>
+          <version>1.0</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss.weld.se</groupId>
+          <artifactId>weld-se</artifactId>
+          <version>1.1.34.Final</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 
 </project>

--- a/src/main/java/org/mybatis/cdi/CDIUtils.java
+++ b/src/main/java/org/mybatis/cdi/CDIUtils.java
@@ -23,8 +23,10 @@ import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Default;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
-import javax.enterprise.inject.spi.CDI;
 import javax.enterprise.util.AnnotationLiteral;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
 import org.apache.ibatis.session.SqlSessionFactory;
 
 /**
@@ -38,13 +40,26 @@ public final class CDIUtils {
   }
 
   /**
+   * Gets a CDI BeanManager instance
+   *
+   * @return BeanManager instance
+   */
+  private static BeanManager getBeanManager() {
+    try {
+      return InitialContext.doLookup("java:comp/BeanManager");
+    } catch (NamingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
    * Gets the registry.
    *
    * @param creationalContext the creational context
    * @return the registry
    */
   public static SqlSessionManagerRegistry getRegistry(CreationalContext creationalContext) {
-    final BeanManager beanManager = CDI.current().getBeanManager();
+    final BeanManager beanManager = getBeanManager();
     Iterator<Bean<?>> beans = beanManager.getBeans(SqlSessionManagerRegistry.class).iterator();
     return (SqlSessionManagerRegistry) beanManager.getReference(beans.next(), SqlSessionManagerRegistry.class,
         creationalContext);
@@ -60,7 +75,7 @@ public final class CDIUtils {
    */
   public static SqlSessionFactory findSqlSessionFactory(String name, Set<Annotation> qualifiers,
       CreationalContext creationalContext) {
-    final BeanManager beanManager = CDI.current().getBeanManager();
+    final BeanManager beanManager = getBeanManager();
     Set<Bean<?>> beans;
     if (name != null) {
       beans = beanManager.getBeans(name);

--- a/src/test/java/org/mybatis/cdi/MockInitialContextFactory.java
+++ b/src/test/java/org/mybatis/cdi/MockInitialContextFactory.java
@@ -1,0 +1,54 @@
+/**
+ *    Copyright 2013-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.cdi;
+
+import java.util.Hashtable;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.naming.spi.InitialContextFactory;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+* Provides a means to mock InitialContext JNDI lookups.
+* Also see src/test/resources/jndi.properties
+*
+* @author Michael Lynch [mwlynch]
+*/
+public class MockInitialContextFactory implements InitialContextFactory {
+
+  @Mock
+  public static InitialContext initialContext;
+
+  public MockInitialContextFactory() {
+    if (initialContext == null) {
+      synchronized (MockInitialContextFactory.class) {
+        if (initialContext == null) {
+          MockitoAnnotations.initMocks(this);
+        }
+      }
+    }
+  }
+
+  @Override
+  public Context getInitialContext(Hashtable<?, ?> envmt) throws NamingException {
+    return initialContext;
+  }
+
+}

--- a/src/test/java/org/mybatis/cdi/WeldJUnit4Runner.java
+++ b/src/test/java/org/mybatis/cdi/WeldJUnit4Runner.java
@@ -15,10 +15,13 @@
  */
 package org.mybatis.cdi;
 
+import javax.naming.InitialContext;
+
 import org.jboss.weld.environment.se.Weld;
 import org.jboss.weld.environment.se.WeldContainer;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.InitializationError;
+import org.mockito.Mockito;
 
 public class WeldJUnit4Runner extends BlockJUnit4ClassRunner {
 
@@ -35,6 +38,7 @@ public class WeldJUnit4Runner extends BlockJUnit4ClassRunner {
 
   @Override
   protected Object createTest() throws Exception {
+    Mockito.when(new InitialContext().doLookup("java:comp/BeanManager")).thenReturn(container.getBeanManager());
     return this.container.instance().select(this.klass).get();
   }
 

--- a/src/test/resources/jndi.properties
+++ b/src/test/resources/jndi.properties
@@ -1,0 +1,17 @@
+#
+#    Copyright 2013-2017 the original author or authors.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+java.naming.factory.initial=org.mybatis.cdi.MockInitialContextFactory

--- a/travis/after_success.sh
+++ b/travis/after_success.sh
@@ -33,7 +33,7 @@ echo "Current commit detected: ${commit_message}"
 
 if [ $TRAVIS_REPO_SLUG == "mybatis/cdi" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ] && [[ "$commit_message" != *"[maven-release-plugin]"* ]]; then
 
-  if [ ${TRAVIS_JDK_VERSION} == "oraclejdk8" ]; then
+  if [ ${TRAVIS_JDK_VERSION} == "oraclejdk8" ] && [ ${MAVEN_PROFILE} == "-Pcdi-1.2" ]; then
 
     # Deploy to sonatype
     ./mvnw clean deploy -q --settings ./travis/settings.xml


### PR DESCRIPTION
This change:
* Changes BeanManager lookup to use JNDI.
* Distinguishes the cdi api from the implementation used during the test phase.
* Provides a profile for testing cdi-1.0
* Provides a profile for testing cdi-1.1
* Provides a profile for testing cdi-1.2
* Provides a profile for testing cdi-2.0
* Makes cdi-1.2 the default profile.
* Updates the README to indicate the new compatibility.
* Excludes non working combinations from the test matrix (currently openjdk7 with CDI 2.0)