### PR TITLE
Update surefire in smarter way from mybatis-parent but note we can only go to 2.21.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <osgi.dynamicImport>*</osgi.dynamicImport>
 
     <!-- Remove once updated to next mybatis-parent -->
-    <surefire.version>2.22.1</surefire.version>
+    <surefire.version>2.21.0</surefire.version> <!-- TODO: Why does everything go horribly wrong on 2.22.0+ -->
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,9 @@
     <findbugs.onlyAnalyze>org.mybatis.cdi.*</findbugs.onlyAnalyze>
     <osgi.import>org.mybatis.*;resolution:=optional,*</osgi.import>
     <osgi.dynamicImport>*</osgi.dynamicImport>
+
+    <!-- Remove once updated to next mybatis-parent -->
+    <surefire.version>2.22.1</surefire.version>
   </properties>
 
   <dependencies>
@@ -124,15 +127,6 @@
   </dependencies>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.19.1</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
See #91 with details on failure to be on latest surefire.