### PR TITLE
[travis] Add matrix support for jdk 8 through 11 (drop 7)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,137 @@
 language: java
 sudo: false
 
-jdk:
-  - oraclejdk9
-  - oraclejdk8
-  - openjdk8
-  - openjdk7
+matrix:
+  include:
+# 11
+    - env:
+      - JDK='Oracle JDK 11'
+      - MAVEN_PROFILE="-Pcdi-2.0"
+      install: . ./install-jdk.sh -F 11 -L BCL
+    - env:
+      - JDK='OpenJDK 11'
+      - MAVEN_PROFILE="-Pcdi-2.0"
+      install: . ./install-jdk.sh -F 11 -L GPL
+
+    - env:
+      - JDK='Oracle JDK 11'
+      - MAVEN_PROFILE="-Pcdi-1.2"
+      install: . ./install-jdk.sh -F 11 -L BCL
+    - env:
+      - JDK='OpenJDK 11'
+      - MAVEN_PROFILE="-Pcdi-1.2"
+      install: . ./install-jdk.sh -F 11 -L GPL
+
+    - env:
+      - JDK='Oracle JDK 11'
+      - MAVEN_PROFILE="-Pcdi-1.1"
+      install: . ./install-jdk.sh -F 11 -L BCL
+    - env:
+      - JDK='OpenJDK 11'
+      - MAVEN_PROFILE="-Pcdi-1.1"
+      install: . ./install-jdk.sh -F 11 -L GPL
+
+# 10
+    - env:
+      - JDK='Oracle JDK 10'
+      - MAVEN_PROFILE="-Pcdi-2.0"
+      install: . ./install-jdk.sh -F 10 -L BCL
+    - env:
+      - JDK='OpenJDK 10'
+      - MAVEN_PROFILE="-Pcdi-2.0"
+      install: . ./install-jdk.sh -F 10 -L GPL
+
+    - env:
+      - JDK='Oracle JDK 10'
+      - MAVEN_PROFILE="-Pcdi-1.2"
+      install: . ./install-jdk.sh -F 10 -L BCL
+    - env:
+      - JDK='OpenJDK 10'
+      - MAVEN_PROFILE="-Pcdi-1.2"
+      install: . ./install-jdk.sh -F 10 -L GPL
+
+    - env:
+      - JDK='Oracle JDK 10'
+      - MAVEN_PROFILE="-Pcdi-1.1"
+      install: . ./install-jdk.sh -F 10 -L BCL
+
+    - env:
+      - JDK='OpenJDK 10'
+      - MAVEN_PROFILE="-Pcdi-1.1"
+      install: . ./install-jdk.sh -F 10 -L GPL
+
+# 9
+    - env:
+      - JDK='Oracle JDK 9'
+      - MAVEN_PROFILE="-Pcdi-2.0"
+      jdk: oraclejdk9
+    - env:
+      - JDK='OpenJDK 9'
+      - MAVEN_PROFILE="-Pcdi-2.0"
+      install: . ./install-jdk.sh -F 9
+
+    - env:
+      - JDK='Oracle JDK 9'
+      - MAVEN_PROFILE="-Pcdi-1.2"
+      jdk: oraclejdk9
+
+    - env:
+      - JDK='OpenJDK 9'
+      - MAVEN_PROFILE="-Pcdi-1.2"
+      install: . ./install-jdk.sh -F 9
+
+    - env:
+      - JDK='Oracle JDK 9'
+      - MAVEN_PROFILE="-Pcdi-1.1"
+      jdk: oraclejdk9
+    - env:
+      - JDK='OpenJDK 9'
+      - MAVEN_PROFILE="-Pcdi-1.1"
+      install: . ./install-jdk.sh -F 9
+      
+# 8
+    - env:
+      - JDK='Oracle JDK 8'
+      - MAVEN_PROFILE="-Pcdi-2.0"
+      jdk: oraclejdk8
+    - env:
+      - JDK='OpenJDK 8'
+      - MAVEN_PROFILE="-Pcdi-2.0"
+      jdk: openjdk8
+
+    - env:
+      - JDK='Oracle JDK 8'
+      - MAVEN_PROFILE="-Pcdi-1.2"
+      jdk: oraclejdk8
+
+    - env:
+      - JDK='OpenJDK 8'
+      - MAVEN_PROFILE="-Pcdi-1.2"
+      jdk: openjdk8
+
+    - env:
+      - JDK='Oracle JDK 8'
+      - MAVEN_PROFILE="-Pcdi-1.1"
+      jdk: oraclejdk8
+    - env:
+      - JDK='OpenJDK 8'
+      - MAVEN_PROFILE="-Pcdi-1.1"
+      jdk: openjdk8
+      
+before_install:
+  - wget https://raw.githubusercontent.com/sormuras/bach/master/install-jdk.sh
+  - ./mvnw install -q -DskipTests=true
+
+install: true
 
 script:
-  - ./mvnw test -B $MAVEN_PROFILE
+  - ./mvnw test -B -V $MAVEN_PROFILE
 
 after_success:
   - chmod -R 777 ./travis/after_success.sh
   - "./travis/after_success.sh"
 
-matrix:
-  exclude:
-  - jdk: openjdk7
-    env: MAVEN_PROFILE="-Pcdi-2.0"
-
 env:
-  matrix:
-    - MAVEN_PROFILE="-Pcdi-2.0"
-    - MAVEN_PROFILE="-Pcdi-1.2"
-    - MAVEN_PROFILE="-Pcdi-1.1"
   global:
     - secure: Yt0S6+G81okW0/575CBg9pP2CcNnilyar2KKDw+4bPnFxlMS0t4y1YyX08p/Zvj5/1q7n88NrPDFdnr/qwZ0gKjmKcYMm4WTCfy+UOPtYhyQSxX6aTYOhYDMpbAQ84jB3Gh70mG52ULXxF56Hc5bNAXT0lSNfIAOndrF/LIBJAU=
     - secure: QAeXjP+BabMYAHSivnbYaxrcr9pj6+FBEO/fpTlB4M0W5nALBoj8nVTOVYGv6zQHV1cxDv4DOLUxg/2sDcrWPyHV+8xbXbHvXK80T4wgeTc/SFEGOINMm/oXGdTGtY6lJ6i5VEDGwJDMRUt+M/W22HD0lqUZNDJ8xL5PAwKVr6g=


### PR DESCRIPTION
10 & 11 fail but will pass upon next set of PRs.

Both 8 & 9 pass as was before.

7 is dropped

9 additionally supported for openjdk

For now allowing the 2 series noted failures as they will clear.  If I have any other issues bringing in additional PRs, I can turn those off for now.  The biggest piece was getting the matrix correct :)