### PR TITLE
[travis] Lesson jdk usage and remove older setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,100 +7,23 @@ matrix:
     - env:
       - JDK='Oracle JDK 11'
       - MAVEN_PROFILE="-Pcdi-2.0"
-      install: . ./install-jdk.sh -F 11 -L BCL
-    - env:
-      - JDK='OpenJDK 11'
-      - MAVEN_PROFILE="-Pcdi-2.0"
-      install: . ./install-jdk.sh -F 11 -L GPL
+      jdk: oraclejdk11
 
     - env:
       - JDK='Oracle JDK 11'
       - MAVEN_PROFILE="-Pcdi-1.2"
-      install: . ./install-jdk.sh -F 11 -L BCL
-    - env:
-      - JDK='OpenJDK 11'
-      - MAVEN_PROFILE="-Pcdi-1.2"
-      install: . ./install-jdk.sh -F 11 -L GPL
+      jdk: oraclejdk11
 
     - env:
       - JDK='Oracle JDK 11'
       - MAVEN_PROFILE="-Pcdi-1.1"
-      install: . ./install-jdk.sh -F 11 -L BCL
-    - env:
-      - JDK='OpenJDK 11'
-      - MAVEN_PROFILE="-Pcdi-1.1"
-      install: . ./install-jdk.sh -F 11 -L GPL
+      jdk: oraclejdk11
 
-# 10
-# Oracle removed (keep in case we can get elsewhere)
-#    - env:
-#      - JDK='Oracle JDK 10'
-#      - MAVEN_PROFILE="-Pcdi-2.0"
-#      install: . ./install-jdk.sh -F 10 -L BCL
-    - env:
-      - JDK='OpenJDK 10'
-      - MAVEN_PROFILE="-Pcdi-2.0"
-      install: . ./install-jdk.sh -F 10 -L GPL
-
-# Oracle removed (keep in case we can get elsewhere)
-#    - env:
-#      - JDK='Oracle JDK 10'
-#      - MAVEN_PROFILE="-Pcdi-1.2"
-#      install: . ./install-jdk.sh -F 10 -L BCL
-    - env:
-      - JDK='OpenJDK 10'
-      - MAVEN_PROFILE="-Pcdi-1.2"
-      install: . ./install-jdk.sh -F 10 -L GPL
-
-# Oracle removed (keep in case we can get elsewhere)
-#    - env:
-#      - JDK='Oracle JDK 10'
-#      - MAVEN_PROFILE="-Pcdi-1.1"
-#      install: . ./install-jdk.sh -F 10 -L BCL
-
-    - env:
-      - JDK='OpenJDK 10'
-      - MAVEN_PROFILE="-Pcdi-1.1"
-      install: . ./install-jdk.sh -F 10 -L GPL
-
-# 9
-    - env:
-      - JDK='Oracle JDK 9'
-      - MAVEN_PROFILE="-Pcdi-2.0"
-      jdk: oraclejdk9
-    - env:
-      - JDK='OpenJDK 9'
-      - MAVEN_PROFILE="-Pcdi-2.0"
-      install: . ./install-jdk.sh -F 9
-
-    - env:
-      - JDK='Oracle JDK 9'
-      - MAVEN_PROFILE="-Pcdi-1.2"
-      jdk: oraclejdk9
-
-    - env:
-      - JDK='OpenJDK 9'
-      - MAVEN_PROFILE="-Pcdi-1.2"
-      install: . ./install-jdk.sh -F 9
-
-    - env:
-      - JDK='Oracle JDK 9'
-      - MAVEN_PROFILE="-Pcdi-1.1"
-      jdk: oraclejdk9
-    - env:
-      - JDK='OpenJDK 9'
-      - MAVEN_PROFILE="-Pcdi-1.1"
-      install: . ./install-jdk.sh -F 9
-      
 # 8
     - env:
       - JDK='Oracle JDK 8'
       - MAVEN_PROFILE="-Pcdi-2.0"
       jdk: oraclejdk8
-    - env:
-      - JDK='OpenJDK 8'
-      - MAVEN_PROFILE="-Pcdi-2.0"
-      jdk: openjdk8
 
     - env:
       - JDK='Oracle JDK 8'
@@ -108,25 +31,10 @@ matrix:
       jdk: oraclejdk8
 
     - env:
-      - JDK='OpenJDK 8'
-      - MAVEN_PROFILE="-Pcdi-1.2"
-      jdk: openjdk8
-
-    - env:
       - JDK='Oracle JDK 8'
       - MAVEN_PROFILE="-Pcdi-1.1"
       jdk: oraclejdk8
-    - env:
-      - JDK='OpenJDK 8'
-      - MAVEN_PROFILE="-Pcdi-1.1"
-      jdk: openjdk8
       
-before_install:
-  - wget https://raw.githubusercontent.com/sormuras/bach/master/install-jdk.sh
-  - ./mvnw install -q -DskipTests=true
-
-install: true
-
 script:
   - ./mvnw test -B -V $MAVEN_PROFILE
 


### PR DESCRIPTION
Older setup post jdk 9 was to use install-jdk.  Travis has now integrated this so it's no longer necessary.