### PR TITLE
Break IOC Tests into two separate tests

### DIFF
--- a/src/test/java/org/mybatis/cdi/FooServiceJTATest.java
+++ b/src/test/java/org/mybatis/cdi/FooServiceJTATest.java
@@ -1,0 +1,91 @@
+/**
+ *    Copyright 2013-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.cdi;
+
+import javax.inject.Inject;
+import javax.transaction.UserTransaction;
+
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.junit5.EnableWeld;
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@EnableWeld
+public class FooServiceJTATest {
+
+  @WeldSetup
+  public WeldInitiator weld = WeldInitiator.of(new Weld());
+
+  @Inject
+  private FooServiceJTA fooServiceJTA;
+
+  @Inject
+  private UserTransaction userTransaction;
+
+  @Test
+  public void jtaShouldGetAUserWithNoTX() throws Exception {
+    this.userTransaction.begin();
+    Assertions.assertEquals("1-User1", this.fooServiceJTA.getUserWithNoTransaction(1).getName());
+    this.userTransaction.commit();
+  }
+
+  @Test
+  public void jtaShouldInsertAUserAndCommit() {
+    User user = new User();
+    user.setId(20);
+    user.setName("User20");
+    this.fooServiceJTA.insertUserWithTransactional(user);
+    Assertions.assertEquals(user.getName(), this.fooServiceJTA.getUserWithNoTransaction(user.getId()).getName());
+  }
+
+  @Test
+  public void jtaShouldInsertAUserAndRollItBack() {
+    User user = new User();
+    user.setId(30);
+    user.setName("User30");
+    try {
+      this.fooServiceJTA.insertUserWithTransactionalAndFail(user);
+    } catch (Exception ignore) {
+      // ignored
+    }
+    Assertions.assertNull(this.fooServiceJTA.getUserWithNoTransaction(user.getId()));
+  }
+
+  @Test
+  public void jtaShouldInsertAUserWithExistingJtaTxAndCommit() throws Exception {
+    User user = new User();
+    user.setId(40);
+    user.setName("User40");
+    this.userTransaction.begin();
+    this.fooServiceJTA.insertUserWithTransactional(user);
+    this.userTransaction.commit();
+    Assertions.assertEquals(user.getName(), this.fooServiceJTA.getUserWithNoTransaction(user.getId()).getName());
+  }
+
+  @Test
+  public void jtaShouldInsertAUserWithExistingJtaTxAndRollItBack() throws Exception {
+    User user = new User();
+    user.setId(50);
+    user.setName("User50");
+    this.userTransaction.begin();
+    this.fooServiceJTA.insertUserWithTransactional(user);
+    this.userTransaction.rollback();
+    Assertions.assertNull(this.fooServiceJTA.getUserWithNoTransaction(user.getId()));
+  }
+
+}

--- a/src/test/java/org/mybatis/cdi/FooServiceTest.java
+++ b/src/test/java/org/mybatis/cdi/FooServiceTest.java
@@ -21,7 +21,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
 import javax.inject.Inject;
-import javax.transaction.UserTransaction;
 
 import org.jboss.weld.environment.se.Weld;
 import org.jboss.weld.junit5.EnableWeld;
@@ -31,16 +30,16 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 @EnableWeld
-public class TestingIoC {
+public class FooServiceTest {
+
+  @WeldSetup
+  public WeldInitiator weld = WeldInitiator.of(new Weld());
 
   @Inject
   private FooService fooService;
 
   @Inject
   private SerializableFooService serFooService;
-
-  @WeldSetup
-  public WeldInitiator weld = WeldInitiator.of(new Weld());
 
   @Test
   public void shouldGetAUser() {
@@ -104,65 +103,6 @@ public class TestingIoC {
       // ignored
     }
     Assertions.assertNull(this.fooService.getUser(30));
-  }
-
-  // TEST JTA
-
-  @Inject
-  private FooServiceJTA fooServiceJTA;
-
-  @Inject
-  private UserTransaction userTransaction;
-
-  @Test
-  public void jtaShouldGetAUserWithNoTX() throws Exception {
-    this.userTransaction.begin();
-    Assertions.assertEquals("1-User1", this.fooServiceJTA.getUserWithNoTransaction(1).getName());
-    this.userTransaction.commit();
-  }
-
-  @Test
-  public void jtaShouldInsertAUserAndCommit() {
-    User user = new User();
-    user.setId(20);
-    user.setName("User20");
-    this.fooServiceJTA.insertUserWithTransactional(user);
-    Assertions.assertEquals(user.getName(), this.fooServiceJTA.getUserWithNoTransaction(user.getId()).getName());
-  }
-
-  @Test
-  public void jtaShouldInsertAUserAndRollItBack() {
-    User user = new User();
-    user.setId(30);
-    user.setName("User30");
-    try {
-      this.fooServiceJTA.insertUserWithTransactionalAndFail(user);
-    } catch (Exception ignore) {
-      // ignored
-    }
-    Assertions.assertNull(this.fooServiceJTA.getUserWithNoTransaction(user.getId()));
-  }
-
-  @Test
-  public void jtaShouldInsertAUserWithExistingJtaTxAndCommit() throws Exception {
-    User user = new User();
-    user.setId(40);
-    user.setName("User40");
-    this.userTransaction.begin();
-    this.fooServiceJTA.insertUserWithTransactional(user);
-    this.userTransaction.commit();
-    Assertions.assertEquals(user.getName(), this.fooServiceJTA.getUserWithNoTransaction(user.getId()).getName());
-  }
-
-  @Test
-  public void jtaShouldInsertAUserWithExistingJtaTxAndRollItBack() throws Exception {
-    User user = new User();
-    user.setId(50);
-    user.setName("User50");
-    this.userTransaction.begin();
-    this.fooServiceJTA.insertUserWithTransactional(user);
-    this.userTransaction.rollback();
-    Assertions.assertNull(this.fooServiceJTA.getUserWithNoTransaction(user.getId()));
   }
 
   @Test

--- a/src/test/java/org/mybatis/cdi/TestingIoC.java
+++ b/src/test/java/org/mybatis/cdi/TestingIoC.java
@@ -24,14 +24,13 @@ import javax.inject.Inject;
 import javax.transaction.UserTransaction;
 
 import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.junit5.EnableWeld;
 import org.jboss.weld.junit5.WeldInitiator;
-import org.jboss.weld.junit5.WeldJunit5Extension;
 import org.jboss.weld.junit5.WeldSetup;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(WeldJunit5Extension.class)
+@EnableWeld
 public class TestingIoC {
 
   @Inject


### PR DESCRIPTION
The tests were clearly distinct with properties being mixed between methods in class.  Break into 2 classes and properly name per standard junit naming convention.