### PR TITLE
[pom] Add patch for eclipse 4.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,13 @@
       <version>5.3.1</version>
       <scope>test</scope>
     </dependency>
+    <!-- Eclipse 4.9 bug, adding junit so eclipse works.  Fixed in 4.10 only (don't commit once working) -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.codehaus.btm</groupId>
       <artifactId>btm</artifactId>


### PR DESCRIPTION
Temporary item until Eclipse 4.10 is released.  Eclipse is on quarterly releases now so the wait won't be long.