### PR TITLE
[pom] Bump weld 3.1.6.Final to 3.1.7.SP1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
         <dependency>
           <groupId>org.jboss.weld.se</groupId>
           <artifactId>weld-se-core</artifactId>
-          <version>3.1.6.Final</version>
+          <version>3.1.7.SP1</version>
           <scope>test</scope>
         </dependency>
       </dependencies>


### PR DESCRIPTION
3.1.7.Final was broken with proxy on jdk 11.  This was fixed.