### PR TITLE
[cleanup] Rewrite logging to use slf4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.32</version>
-      <scope>test</scope>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
weld uses jboss logging anyways not java util logging.  It tries to log with jboss first then switches to slf4j.  So just use slf4j which cleans up logging and was already present during tests.  Its most likely to be present anyways.