### PR TITLE
[GHA] Drop java 11 from build matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java: [11, 17, 21, 22-ea]
+        java: [17, 21, 22-ea]
         distribution: ['temurin']
       fail-fast: false
       max-parallel: 4


### PR DESCRIPTION
lets derby move up.  Code is locked to java 11 so there is no real harm in doing so.