### PR TITLE
[fix] Resolve site clirr issue as it needs profile for old version fixes #375

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,3 @@
 -Daether.checksums.algorithms=SHA-512,SHA-256,SHA-1,MD5
 -Daether.connector.smartChecksums=false
+-Pcdi-2.0


### PR DESCRIPTION
fixes #375

set profile to the default that was used previously to build javax namespace.  It will throw warning on new builds but that is ok as we need site working properly.  It can be removed once we no longer compare to javax namespace.