### PR TITLE
Add hack back for topSiteURL for now

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,7 @@
         <artifactId>maven-site-plugin</artifactId>
         <configuration>
           <locales>default,zh_CN</locales>
+          <!-- Hack for single site builds so site:staging works as expected. Do not use with multi module! -->
           <topSiteURL>${project.distributionManagement.site.url}</topSiteURL>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,7 @@
         <artifactId>maven-site-plugin</artifactId>
         <configuration>
           <locales>default,zh_CN</locales>
+          <topSiteURL>${project.distributionManagement.site.url}</topSiteURL>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Still unable to figure out why site tries to add 'cdi.git' as the site URL and then uses .. to push that back up into target folder outside of the staging area.